### PR TITLE
Gmann affinipay/configs and secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This sample deployment creates a simple ExternalName Service, a LoadBalancer Ser
 
 Once running, the Node application will listen for requests on the root path, and proxy the content of the ExternalName service. This demonstrates an exposed internal service that is able to access an external host using CoreDNS.
 
-Inside each pod is a set of environment variables created from key:value map files, including a simple set of admin/password secrets.
+Inside each pod is a set of environment variables created from key:value map files, including a simple set of admin/password secrets. To further demonstrate configuration mapping, the app.properties config map is mounted as the volume /etc/config.
 
 Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes examples](https://github.com/jonbcampos/kubernetes-series).
 
@@ -85,3 +85,9 @@ Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes e
 
     kubectl exec -it my-internal-service-58485bbcb9-8cdh5 -- env | grep mascot
     lawpay.enabled.mascot=unicorn`
+
+6. See the mounted config volume inside the pods (_your pod name will slightly vary_)
+
+   `kubectl exec -it my-internal-service-5557946c59-h24k8 -- ls /etc/config
+   kubectl exec -it my-internal-service-5557946c59-h24k8 -- cat /etc/config/company
+   kubectl exec -it my-internal-service-5557946c59-h24k8 -- cat /etc/config/brands`

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ Sample configurations and secrets were imported as part of container deployment.
    company:
    ----
    affinipay
-   lawpay.enabled:
+   website.enabled:
    ----
    true
-   lawpay.enabled.mascot:
+   website.enabled.mascot:
    ----
-   unicorn
+   ranger
    Events:  <none>
    ```
 
@@ -177,7 +177,7 @@ Sample configurations and secrets were imported as part of container deployment.
 
    ```
    kubectl exec -it my-internal-service-58485bbcb9-8cdh5 -- env | grep mascot
-   lawpay.enabled.mascot=unicorn
+   website.enabled.mascot=ranger
    ```
 
 4. See the mounted config volume inside the pods (_your pod name will slightly vary_)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ This sample deployment creates a simple ExternalName Service, a LoadBalancer Ser
 
 Once running, the Node application will listen for requests on the root path, and proxy the content of the ExternalName service. This demonstrates an exposed internal service that is able to access an external host using CoreDNS.
 
-Inside each pod is a set of environment variables created from key:value map files, including a simple set of admin/password secrets. To further demonstrate configuration mapping, the app.properties config map is mounted as the volume /etc/config.
+Inside each pod is a set of environment variables created from key:value map files. To further demonstrate configuration mapping, the app.properties config map is mounted as the volume /etc/config.
+
+Two simple sets of secrets are provided and exposed to each pod as ENV variables. Each set demonstrates a different way of creating secrets. All secrets are stored in the API server as plaintext at rest in etcd, and for this effort, they are available to all admin users. (No sensitive data is checked into this branch, only demonstration data.)
 
 Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes examples](https://github.com/jonbcampos/kubernetes-series).
 
@@ -91,3 +93,47 @@ Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes e
    `kubectl exec -it my-internal-service-5557946c59-h24k8 -- ls /etc/config
    kubectl exec -it my-internal-service-5557946c59-h24k8 -- cat /etc/config/company
    kubectl exec -it my-internal-service-5557946c59-h24k8 -- cat /etc/config/brands`
+
+7. See the base64 encoded secrets created from YAML
+   `kubectl get secret mysecret -o yaml
+
+    apiVersion: v1
+    data:
+      password: MWYyZDFlMmU2N2Rm
+      username: YWRtaW4=
+    kind: Secret
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/last-applied-configuration: |
+          {"apiVersion":"v1","data":{"password":"MWYyZDFlMmU2N2Rm","username":"YWRtaW4="},"kind":"Secret","metadata":{"annotations":{},"name":"mysecret","namespace":"default"},"type":"Opaque"}
+      creationTimestamp: 2018-10-15T16:37:56Z
+      name: mysecret
+      namespace: default
+      resourceVersion: "109592"
+      selfLink: /api/v1/namespaces/default/secrets/mysecret
+      uid: ab84051e-d098-11e8-a026-080027239c66
+    type: Opaque`
+
+    `echo -n YWRtaW4= | base64
+    admin`
+
+8. See the base64 encoded secrets created from plain text files
+
+   `kubectl get secret db-user-pass -o yaml
+
+    apiVersion: v1
+    data:
+      db-pass: TWpNNFprUkpVaWxSSkd0elpYST0=
+      db-user: WkdKaFpHMXBiZz09
+    kind: Secret
+    metadata:
+      creationTimestamp: 2018-10-15T16:37:56Z
+      name: db-user-pass
+      namespace: default
+      resourceVersion: "109594"
+      selfLink: /api/v1/namespaces/default/secrets/db-user-pass
+      uid: ab9f5ef8-d098-11e8-a026-080027239c66
+    type: Opaque
+
+    echo -n WkdKaFpHMXBiZz09 | base64
+    dbadmin`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This sample deployment creates a simple ExternalName Service, a LoadBalancer Ser
 
 Once running, the Node application will listen for requests on the root path, and proxy the content of the ExternalName service. This demonstrates an exposed internal service that is able to access an external host using CoreDNS.
 
+Inside each pod is a set of environment variables created from key:value map files, including a simple set of admin/password secrets.
+
 Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes examples](https://github.com/jonbcampos/kubernetes-series).
 
 ### Prerequisites
@@ -10,6 +12,8 @@ Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes e
 2. Install the [Kubernetes CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 3. Setup a local Kubernetes cluster with [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
 4. Ensure you are [running CoreDNS in Minikube](https://coredns.io/2017/04/28/coredns-for-minikube/).
+5. Ensure you have enabled ingress in Minikube
+   `minikube addons enable ingress`
 
 ### Running the Deployment
 
@@ -69,3 +73,15 @@ Thanks to [Jonathan Campos](https://github.com/jonbcampos) for his [Kubernetes e
    `kubectl delete pod my-internal-service-55d6c4bcc7-8bpvz` will terminate the pod
 
    `kubectl get pods` will show one terminating and another starting
+
+5. See all environment variables exposed inside the pods (_your pod name will slightly vary_)
+   `kubectl exec -it my-internal-service-5557946c59-h24k8 -- env`
+
+   Grep for any environment variable found in the ./configs files, or any secret found in the ./secrets files. Examples
+
+   `kubectl exec -it my-internal-service-58485bbcb9-8cdh5 -- env | grep user
+    username=admin
+    db-user.txt=dbadmin
+
+    kubectl exec -it my-internal-service-58485bbcb9-8cdh5 -- env | grep mascot
+    lawpay.enabled.mascot=unicorn`

--- a/configs/app-env-file.properties
+++ b/configs/app-env-file.properties
@@ -1,0 +1,5 @@
+payments=TSYS
+tries=3
+allowed="true"
+
+# This comment and the empty line above it are ignored

--- a/configs/app-env-file.properties
+++ b/configs/app-env-file.properties
@@ -1,4 +1,4 @@
-payments=TSYS
+classification=cattle
 tries=3
 allowed="true"
 

--- a/configs/app.properties
+++ b/configs/app.properties
@@ -1,0 +1,4 @@
+company=affinipay
+brands=3
+lawpay.enabled=true
+lawpay.enabled.mascot=unicorn

--- a/configs/app.properties
+++ b/configs/app.properties
@@ -1,4 +1,4 @@
 company=affinipay
 brands=3
-lawpay.enabled=true
-lawpay.enabled.mascot=unicorn
+website.enabled=true
+website.enabled.mascot=ranger

--- a/configs/ui.properties
+++ b/configs/ui.properties
@@ -1,0 +1,4 @@
+color.good=gold
+color.bad=purple
+allow.textmode=true
+how.nice.to.look=fairlyNice

--- a/external-service/deployment.yaml
+++ b/external-service/deployment.yaml
@@ -26,4 +26,16 @@ spec:
           # Force local registry lookup
           imagePullPolicy: Never
           ports:
-            - containerPort: 3000
+          - containerPort: 3000
+          #command: [ "/bin/sh", "-c", "env" ]
+          envFrom:
+          - secretRef:
+              name: mysecret
+          - secretRef:
+              name: db-user-pass
+          - configMapRef:
+              name: app-env-file.properties
+          - configMapRef:
+              name: app.properties
+          - configMapRef:
+              name: ui.properties

--- a/external-service/deployment.yaml
+++ b/external-service/deployment.yaml
@@ -25,9 +25,11 @@ spec:
           image: internal-service-sample:latest
           # Force local registry lookup
           imagePullPolicy: Never
+          volumeMounts:
+          - name: app-config-volume
+            mountPath: /etc/config
           ports:
           - containerPort: 3000
-          #command: [ "/bin/sh", "-c", "env" ]
           envFrom:
           - secretRef:
               name: mysecret
@@ -39,3 +41,9 @@ spec:
               name: app.properties
           - configMapRef:
               name: ui.properties
+      volumes:
+      - name: app-config-volume
+        configMap:
+          # Provide the name of the ConfigMap containing the files you want
+          # to add to the container
+          name: app.properties

--- a/sample-app/app.js
+++ b/sample-app/app.js
@@ -29,4 +29,4 @@ app.get('/hello', (req, res) => {
   res.end()
 })
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+app.listen(port, () => console.log(`Example app listening on host port ${port}!`))

--- a/secrets/db/db-pass
+++ b/secrets/db/db-pass
@@ -1,0 +1,1 @@
+238fDIR)Q$kser

--- a/secrets/db/db-user
+++ b/secrets/db/db-user
@@ -1,0 +1,1 @@
+dbadmin

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  # Encoded base64, decoded by K8s
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 ./destroy.sh
 
+kubectl delete secret mysecret
+kubectl apply -f ./secrets/secrets.yaml
+kubectl delete secret db-user-pass
+kubectl create secret generic db-user-pass --from-file=./secrets/db/
+
+for filename in ls ./configs/* ]; do
+    [ -e "$filename" ] || continue
+    kubectl delete configmap ${filename##*/}
+    kubectl create configmap ${filename##*/} --from-env-file=$filename
+done
+
 docker build ./sample-app -t internal-service-sample
 
 kubectl apply -f ./external-service


### PR DESCRIPTION
Here's an addition of configs and secrets. Demonstrating how configs can be delivered, mounted, and exposed. Also demonstrating two different deliveries of secrets, and how they can be exposed to the containers as ENV variables.

Configs are demonstrated as:

- Import via text files containing key:value maps
- Exposed inside the container as ENV variables
- Mounted inside the container as a volume
 
Secrets are demonstrated as:

- Base64 encoded yaml
- Regular .txt files, imported from a directory
- All exposed to each container as ENV variables